### PR TITLE
fix session handling and support for LJ2

### DIFF
--- a/bin/tir
+++ b/bin/tir
@@ -20,7 +20,7 @@ function parse_args(arg)
     local last_opt = nil
 
     for i, opt in ipairs(arg) do
-        local token = opt:match("\-+([a-z\-]+)")
+        local token = opt:match("%-+([a-z%-]+)")
 
         if token then
             last_opt = token

--- a/tir/session.lua
+++ b/tir/session.lua
@@ -54,7 +54,7 @@ function parse_session_id(cookie)
 
 	local cookie = parse_http_cookie(cookie)
 	
-	return cookie.session
+	return cookie.session[1]
 end
 
 

--- a/tir/session.lua
+++ b/tir/session.lua
@@ -40,21 +40,21 @@ function make_expires()
 end
 
 function make_session_cookie(ident)
-	local cookie = {}
-	cookie.key = 'session'
-	cookie.value = ident or make_session_id()
-	cookie.version = 1
-	cookie.path = '/'
-	cookie.expires = make_expires()
-	return cookie
+    local cookie = {}
+    cookie.key = 'session'
+    cookie.value = ident or make_session_id()
+    cookie.version = 1
+    cookie.path = '/'
+    cookie.expires = make_expires()
+    return cookie
 end
 
 function parse_session_id(cookie)
     if not cookie then return nil end
 
-	local cookie = parse_http_cookie(cookie)
-	
-	return cookie.session[1]
+    local cookie = parse_http_cookie(cookie)
+    
+    return cookie.session[1]
 end
 
 
@@ -77,7 +77,7 @@ function http_cookie_ident(req)
         ident = make_session_id()
         local cookie = make_session_cookie(ident)
 
-		set_http_cookie(req, cookie)
+        set_http_cookie(req, cookie)
         req.session_id = ident
     end
 

--- a/tir/util.lua
+++ b/tir/util.lua
@@ -150,54 +150,55 @@ end
 -- Note:  A cookie string may contain multiple cookies with the same key,
 -- (which can happen if similar cookies exist for different paths, domains, etc.)
 function parse_http_cookie(cookie)
-	local cookies = {}
+    local cookies = {}
 
-	if( not cookie ) then return {} end
+    if not cookie then return {} end
 
-	local cookie_str = string.gsub(cookie, "%s*;%s*", ";")   -- remove extra spaces
-  
-	for k, v in string.gmatch(cookie_str, "([^;]+)=([^;]+)") do
-		-- if the key already exists,then just insert the new value
-		if( cookies[k] ) then
-			table.insert(cookies[k], v)
-		-- otherwise, assign the new key to a table containing the one new value
-		else
-			cookies[k] = {v}
-		end
-	end
+    local cookie_str = string.gsub(cookie, "%s*;%s*", ";")   -- remove extra spaces
 
-	return cookies		
+    for k, v in string.gmatch(cookie_str, "([^;]+)=([^;]+)") do
+        -- if the key already exists,then just insert the new value
+        if cookies[k] then
+            table.insert(cookies[k], v)
+        -- otherwise, assign the new key to a table containing the one new value
+        else
+            cookies[k] = {v}
+        end
+    end
+
+    return cookies		
 end
 
 function set_http_cookie(req, cookie)
-	--key and value are required, everything else is optional
-	assert(cookie and cookie.key and cookie.value, "cookie.key and cookie.value are required")
-	--strip out cookie key/value delimiters
-	local key = string.gsub(cookie.key, "([=;]+)", "")
-	local value = string.gsub(cookie.value, "([=;]+)", "")
-	
-	local cookie_str = key .. '=' .. value
-	
-	-- if no path is specified, use the root
-	cookie_str = cookie_str .. '; ' .. 'path=' .. (cookie.path or '/')
-	
-	if( cookie.domain ) then
-		cookie_str = cookie_str .. ';' .. 'domain=' .. cookie.domain
-	end
-	
-	if( cookie.expires ) then
-		assert("number" == type(cookie.expires), "expires value must be a number - UNIX epoch seconds")
-		cookie_str = cookie_str .. ';' .. 'expires=' .. os.date("%a, %d-%b-%Y %X GMT", cookie.expires)
-	end		
-	  
-	if( cookie.http_only ) then cookie_str = cookie_str .. '; httponly' end
-	
-	if( cookie.secure ) then cookie_str = cookie_str .. '; secure' end
-	
-	-- make sure we actually have a headers table before we go trying to set stuff
-	req.headers = req.headers or {}
-	-- make sure we have a set-cookie table to work with
-	req.headers['set-cookie'] = req.headers['set-cookie'] or {}
-	--insert the new cookie as a new set-cookie response header
-	table.insert(req.headers['set-cookie'], cookie_str)	
+    --key and value are required, everything else is optional
+    assert(cookie and cookie.key and cookie.value, "cookie.key and cookie.value are required")
+    --strip out cookie key/value delimiters
+    local key = string.gsub(cookie.key, "([=;]+)", "")
+    local value = string.gsub(cookie.value, "([=;]+)", "")
+    
+    local cookie_str = key .. '=' .. value
+    
+    -- if no path is specified, use the root
+    cookie_str = cookie_str .. '; ' .. 'path=' .. (cookie.path or '/')
+    
+    if cookie.domain then
+        cookie_str = cookie_str .. ';' .. 'domain=' .. cookie.domain
+    end
+    
+    if cookie.expires then
+        assert("number" == type(cookie.expires), "expires value must be a number - UNIX epoch seconds")
+        cookie_str = cookie_str .. ';' .. 'expires=' .. os.date("%a, %d-%b-%Y %X GMT", cookie.expires)
+    end		
+      
+    if cookie.http_only then cookie_str = cookie_str .. '; httponly' end
+    
+    if cookie.secure then cookie_str = cookie_str .. '; secure' end
+    
+    -- make sure we actually have a headers table before we go trying to set stuff
+    req.headers = req.headers or {}
+    -- make sure we have a set-cookie table to work with
+    req.headers['set-cookie'] = req.headers['set-cookie'] or {}
+    --insert the new cookie as a new set-cookie response header
+    table.insert(req.headers['set-cookie'], cookie_str)	
 end
+


### PR DESCRIPTION
Hi, the recent changes which unconditionally parse cookie values into tables breaks the session logic so that run_coro can't find the state it needs. I've fixed this and also fixed an issue with escapes in patterns which LuaJIT is less tolerant of.
