### PR TITLE
Allow overiding of pub_addr and sub_addr.  Ignore mongrel sql if config_db is not set.

### DIFF
--- a/rockspec/tir-scm-0.rockspec
+++ b/rockspec/tir-scm-0.rockspec
@@ -19,6 +19,7 @@ dependencies = {
     "luajson",
     "lsqlite3",
     "telescope",
+    "tnetstrings",
 }
 build = {
     type = "none",

--- a/tests/base/engine_tests.lua
+++ b/tests/base/engine_tests.lua
@@ -1,0 +1,33 @@
+require 'tir.engine'
+
+
+function fake_main()
+    print("TEST")
+end
+
+context("Tir", function()
+    context("engine", function()
+        test("start", function()
+            Tir.run = function() return true end
+            Tir.M2.connect = function() return true end
+             
+            local config = {config_file = 'tests/data/config.lua', route = '/arc'}
+            Tir.start(config)
+    
+            assert_equal('tcp://127.0.0.1:9990', config.sub_addr)
+            assert_equal('tcp://127.0.0.1:9989', config.pub_addr)
+        end)
+
+        test("start-overide", function()
+            Tir.run = function() return true end
+            Tir.M2.connect = function() return true end
+             
+            local config = {config_file = 'tests/data/config.lua', route = '/arc', pub_addr = 'tcp://10.234.56.71:9990', sub_addr = 'tcp://10.234.56.71:9989'}
+            Tir.start(config)
+    
+            assert_equal('tcp://10.234.56.71:9990', config.pub_addr)
+            assert_equal('tcp://10.234.56.71:9989', config.sub_addr)
+            end)        
+    end)
+end)
+

--- a/tests/base/web_tests.lua
+++ b/tests/base/web_tests.lua
@@ -67,13 +67,18 @@ context("Tir", function()
 
         test("get_cookie", function()
             local web = Tir.web(fake_conn, fake_main, fake_req, false)
-            local cookie = web:get_cookie()
+
+            Tir.set_http_cookie(web.req, web.req.headers.cookie)
+            web.req.headers['cookie'] = web.req.headers['set-cookie'][1]
+            web.req.headers['set-cookie'] = nil
+
+            local cookie = web:get_cookies()
             assert_not_nil(cookie)
         end)
 
         test("set_cookie", function()
             local web = Tir.web(fake_conn, fake_main, fake_req, false)
-            web:set_cookie("testing")
+            web:set_cookie({key = "testing", value = ""})
             assert_not_nil(fake_req.headers['set-cookie'])
             fake_req.headers['set-cookie'] = nil
         end)

--- a/tests/data/config.lua
+++ b/tests/data/config.lua
@@ -1,0 +1,1 @@
+config_db = 'tests/data/config.sqlite'

--- a/tir/engine.lua
+++ b/tir/engine.lua
@@ -164,7 +164,11 @@ function start(config)
 
     config.allowed_methods_header = table.concat(allowed, ' ')
 
-    Tir.M2.load_config(config)
+    if config.config_db then Tir.M2.load_config(config) end
+
+    assert(config.sub_addr, "Failed to find sub_addr.")
+    assert(config.pub_addr, "Failed to find pub_addr.")
+
     local conn = assert(Tir.M2.connect(config), "Failed to connect to Mongrel2.")
 
     -- Run the engine

--- a/tir/m2.lua
+++ b/tir/m2.lua
@@ -27,8 +27,8 @@ function load_config(config)
     assert(handler, "Failed to find route: " .. config.route ..
             ". Make sure you set config.host to a host in your mongrel2.conf.")
 
-    config.sub_addr = handler.send_spec
-    config.pub_addr = handler.recv_spec
+    config.sub_addr = config.sub_addr or handler.send_spec
+    config.pub_addr = config.pub_addr or handler.recv_spec
 end
 
 

--- a/tir/util.lua
+++ b/tir/util.lua
@@ -182,12 +182,12 @@ function set_http_cookie(req, cookie)
     cookie_str = cookie_str .. '; ' .. 'path=' .. (cookie.path or '/')
     
     if cookie.domain then
-        cookie_str = cookie_str .. ';' .. 'domain=' .. cookie.domain
+        cookie_str = cookie_str .. '; ' .. 'domain=' .. cookie.domain
     end
     
     if cookie.expires then
         assert("number" == type(cookie.expires), "expires value must be a number - UNIX epoch seconds")
-        cookie_str = cookie_str .. ';' .. 'expires=' .. os.date("%a, %d-%b-%Y %X GMT", cookie.expires)
+        cookie_str = cookie_str .. '; ' .. 'expires=' .. os.date("%a, %d-%b-%Y %X GMT", cookie.expires)
     end		
       
     if cookie.http_only then cookie_str = cookie_str .. '; httponly' end


### PR DESCRIPTION
Also in this pull request are changes to the tests to align them with the code and get them passing.  They could use another pass through since they are now using other methods within tir to set the pre-state so they are pretty fragile.
