### PR TITLE
Fixed goofy highlighting with the templating language code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ language and not some crippled one someone smarter than you thinks you should be
 using. And Lua already looks like most of the nice template languages out
 there:
 
-```lua
+```
   {% if #results &gt; 0 then %}
   &lt;ul&gt;
       {% for _,result in ipairs(results) do %}


### PR DESCRIPTION
Fixed the weird highlighting in README.md in the code example near "Simple Templating Language".
